### PR TITLE
Add editable card template with side-by-side layout

### DIFF
--- a/eyas.com/src/App.css
+++ b/eyas.com/src/App.css
@@ -24,6 +24,16 @@
   color: white;
 }
 
+/* -------------------------------------------------------------------------- */
+/* Layout for the example cards */
+/* -------------------------------------------------------------------------- */
+.card-container {
+  display: flex;
+  justify-content: center;
+  gap: 16px; /* Space between cards */
+  margin-top: 24px;
+}
+
 .App-link {
   color: #61dafb;
 }

--- a/eyas.com/src/App.js
+++ b/eyas.com/src/App.js
@@ -1,28 +1,32 @@
-import React from 'react';               // Import React for JSX support
-import Card from './components/Card';    // Import the Card component you created
-import logo from './logo.svg';           // Import the React logo
-import './App.css';                      // Import the default styles
+import React from 'react'; // Import React for JSX support
+import Card from './components/Card';    // Our simple Card component
+import logo from './logo.svg';           // React logo shown in the header
+import './App.css';                      // Global styles for the app
 
 function App() {
-  return (
-    // contains the app
-    <div className="App">
+  // -------------------------------------------------------------------------
+  // Card data for this page.  Simply edit the objects below to change the
+  // displayed cards.  Each object must contain a `title` and `content` field.
+  // -------------------------------------------------------------------------
+  const cards = [
+    { title: 'Card 1', content: 'content card 1' },
+    { title: 'Card 2', content: 'content card 2' },
+    { title: 'Card 3', content: 'content card 3' }
+  ];
 
-      {/* Header section */}
+  return (
+    <div className="App">
+      {/* Main header section */}
       <header className="App-header">
-      
-       {/* headder for this app 
-       h1 is the big headder */}
         <h1>Eyas.com!</h1>
-        
-        {/* React logo image */}
         <img src={logo} className="App-logo" alt="logo" />
 
-        {/* Your custom Card component displayed below */}
-        {/* Your custom reusable Card components */}
-        <Card title="Welcome!" content="This is your first custom card." />
-        <Card title="About Us" content="We use data to solve cool problems." />
-        <Card title="Contact" content="Reach out to Eyas at eyas.com/contact." />
+        {/* Container holding all cards side by side */}
+        <div className="card-container">
+          {cards.map((card) => (
+            <Card key={card.title} title={card.title} content={card.content} />
+          ))}
+        </div>
       </header>
     </div>
   );

--- a/eyas.com/src/App.test.js
+++ b/eyas.com/src/App.test.js
@@ -1,8 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders example cards', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  // Verify that the first card is rendered by checking for its heading text.
+  const cardHeading = screen.getByRole('heading', { name: /card 1/i });
+  expect(cardHeading).toBeInTheDocument();
 });

--- a/eyas.com/src/components/Card.jsx
+++ b/eyas.com/src/components/Card.jsx
@@ -1,5 +1,14 @@
 import React from 'react';
 
+// ---------------------------------------------------------------------------
+// Card Component
+// ---------------------------------------------------------------------------
+// This is a very small presentational component used throughout the site.
+// It simply displays a title and some content inside a styled container.
+// Keeping the component small and reusable makes it easy to drop cards into
+// any page by just passing `title` and `content` props. Styling is intentionally minimal so it can easily be overridden if needed.
+// ---------------------------------------------------------------------------
+
 const Card = ({ title, content }) => {
   return (
     <div style={{ border: '1px solid #ccc', padding: '16px', borderRadius: '8px', backgroundColor: '#fff' }}>


### PR DESCRIPTION
## Summary
- use an array in `App.js` for easy card editing
- display cards side-by-side with new `.card-container` style
- document the `Card` component with helpful comments
- update unit test to check for example card

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884225b20f483239720a4b447e93fe4